### PR TITLE
allow goal to be a function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /doc/
 /tags
 /bench/snapshots/
+.elixir_ls

--- a/lib/astar.ex
+++ b/lib/astar.ex
@@ -43,7 +43,7 @@ defmodule Astar do
   defp loop({nbs, dist, h}=env, goal, openmap, closedset, parents) do
       {_fx, x, openmap} = HeapMap.pop(openmap)
       if has_reached_goal?(x, goal) do
-        cons_path(parents, goal)
+        cons_path(parents, x)
       else
 
         closedset = MapSet.put(closedset, x)

--- a/lib/astar.ex
+++ b/lib/astar.ex
@@ -33,6 +33,8 @@ defmodule Astar do
     loop(env, goal, openmap, MapSet.new, Map.new)
   end
 
+  defp has_reached_goal?(x, goal) when is_function(goal), do: goal.(x)
+  defp has_reached_goal?(x, goal), do: x == goal
 
   @spec loop(env, vertex, HeapMap.t, MapSet.t, Map.t) :: [vertex]
 
@@ -40,7 +42,7 @@ defmodule Astar do
 
   defp loop({nbs, dist, h}=env, goal, openmap, closedset, parents) do
       {_fx, x, openmap} = HeapMap.pop(openmap)
-      if x == goal do
+      if has_reached_goal?(x, goal) do
         cons_path(parents, goal)
       else
 

--- a/test/is_goal_test.exs
+++ b/test/is_goal_test.exs
@@ -1,0 +1,44 @@
+defmodule Astar.IsGoal.Test do
+  use ExUnit.Case
+
+  @nodes %{
+    1 => [
+      %{distance: 7.5, id: 2}
+    ],
+    2 => [
+      %{distance: 7.5, id: 1},
+      %{distance: 6.1, id: 3}
+    ],
+    3 => [
+      %{distance: 6.1, id: 2},
+      %{distance: 6.2, id: 4}
+    ],
+    4 => [
+      %{distance: 6.2, id: 3},
+      %{distance: 7.1, id: 5}
+    ],
+    5 => [%{distance: 7.1, id: 4}]
+  }
+
+  @goals [5, 6]
+
+  test "using an is_goal function" do
+    nbs = fn id ->
+      @nodes[id]
+      |> Enum.map(& &1.id)
+    end
+
+    dist = fn id1, id2 ->
+      @nodes[id1]
+      |> Enum.filter(&(&1.id == id2))
+      |> List.first()
+      |> Map.get(:distance)
+    end
+
+    h = fn id, _ -> -id end
+    env = {nbs, dist, h}
+
+    path = Astar.astar(env, 1, fn id -> Enum.member?(@goals, id) end)
+    assert path == [2, 3, 4, 5]
+  end
+end


### PR DESCRIPTION
I have a use case where there are multiple possible goals, and the heuristic can be calculated without knowing the goal. This pull request allows users to set the goal as a function that will return true if the current node is a goal node.

I'm pretty sure that when a function is used for the goal, the heuristic function will receive this function as it's second argument.

I have included a unit test, but haven't updated the documentation. Additionally I think the property tests and TravisCI might be broken due to outdated dependencies.